### PR TITLE
fix(scheduler): consolidate ScheduleModule.forRoot() to AppModule only

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -21,6 +21,7 @@ import { HealthController } from './health.controller';
 import { BrokerageModule } from './brokerage/brokerage.module';
 import { RealEstateModule } from './real-estate/real-estate.module';
 import { GoalsModule } from './goals/goals.module';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
   imports: [
@@ -41,6 +42,7 @@ import { GoalsModule } from './goals/goals.module';
         ]
       : []),
     ConfigModule.forRoot({ isGlobal: true }),
+    ScheduleModule.forRoot(),
     PrismaModule,
     DatabaseModule,
     AuthModule,

--- a/apps/api/src/database/database.module.ts
+++ b/apps/api/src/database/database.module.ts
@@ -1,10 +1,9 @@
 import { Module } from '@nestjs/common';
-import { ScheduleModule } from '@nestjs/schedule';
 import { DatabaseService } from './database.service';
 import { DatabaseController } from './database.controller';
 
 @Module({
-  imports: [ScheduleModule.forRoot()],
+  imports: [],
   controllers: [DatabaseController],
   providers: [DatabaseService],
   exports: [DatabaseService],

--- a/apps/api/src/ynab/ynab.module.ts
+++ b/apps/api/src/ynab/ynab.module.ts
@@ -1,11 +1,10 @@
 import { Module } from '@nestjs/common';
-import { ScheduleModule } from '@nestjs/schedule';
 import { YnabService } from './ynab.service';
 import { YnabController } from './ynab.controller';
 import { YnabSyncScheduler } from './ynab.scheduler';
 
 @Module({
-  imports: [ScheduleModule.forRoot()],
+  imports: [],
   providers: [YnabService, YnabSyncScheduler],
   controllers: [YnabController],
   exports: [YnabService],


### PR DESCRIPTION
## Problem

`ScheduleModule.forRoot()` was registered in both `YnabModule` and `DatabaseModule`. This caused the NestJS scheduler to register all `@Cron` jobs twice, so every cron tick fired each job twice. The visible symptom was duplicate log lines and errors from the YNAB scheduled sync:

```
LOG  [YnabService] Scheduled YNAB sync: 1 connections
LOG  [YnabService] Scheduled YNAB sync: 1 connections   ← duplicate
ERROR [YnabService] Sync failed for user ...: ...
ERROR [YnabService] Sync failed for user ...: ...        ← duplicate
```

## Fix

Move the single `ScheduleModule.forRoot()` call to `AppModule` (the correct root location) and remove it from `YnabModule` and `DatabaseModule`. Feature modules do not need to import `ScheduleModule` — provideMove the single `ScheduleModule.forRoot()` call to `AppModule` (the correct root location) and remove it from `YnabModule` and `DatabaseModule`. Feature modules do not need to import `ScheduleModule` — provideMove the single `Scheom switching the data directory profile in the desktop app) after the YNAB token was stored. The fix is to go to Integrations → disconnect YNAB → reconnect it.