### PR TITLE
fix(docs): move Buy Me a Coffee button to docs page footer

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -9,7 +9,8 @@ COPY packages/finance-engine/package*.json ./packages/finance-engine/
 COPY apps/api/package*.json ./apps/api/
 COPY prisma ./prisma/
 
-RUN npm ci --workspace=packages/shared --workspace=packages/finance-engine --workspace=apps/api
+RUN npm ci --workspace=packages/shared --workspace=packages/finance-engine --workspace=apps/api \
+	&& npx prisma generate
 
 COPY packages/shared ./packages/shared/
 COPY packages/finance-engine ./packages/finance-engine/

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -11,26 +11,9 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
     />
-    <style>
-      footer.app-footer {
-        text-align: center;
-        padding: 12px 0;
-        border-top: 1px solid currentColor;
-      }
-
-      footer.app-footer img {
-        height: 40px;
-        width: auto;
-      }
-    </style>
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <footer class="app-footer">
-      <a href="https://www.buymeacoffee.com/ai.joe" target="_blank" rel="noopener noreferrer">
-        <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" referrerpolicy="no-referrer" loading="lazy" decoding="async" />
-      </a>
-    </footer>
   </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -600,7 +600,7 @@
     <a href="https://github.com/JoeRegnier/retiree-plan/blob/main/LICENSE">MIT License</a> &nbsp;·&nbsp;
     <a href="https://github.com/JoeRegnier/retiree-plan/discussions">Discussions</a>
   </p>
-  <p style="margin-top:0.75rem;">
+  <p style="margin-top: 0.75rem;">
     <a href="https://www.buymeacoffee.com/ai.joe" target="_blank" rel="noopener noreferrer">
       <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height:40px;width:auto;" loading="lazy" decoding="async" referrerpolicy="no-referrer" />
     </a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -600,6 +600,11 @@
     <a href="https://github.com/JoeRegnier/retiree-plan/blob/main/LICENSE">MIT License</a> &nbsp;·&nbsp;
     <a href="https://github.com/JoeRegnier/retiree-plan/discussions">Discussions</a>
   </p>
+  <p style="margin-top:0.75rem;">
+    <a href="https://www.buymeacoffee.com/ai.joe" target="_blank" rel="noopener noreferrer">
+      <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height:40px;width:auto;" loading="lazy" decoding="async" referrerpolicy="no-referrer" />
+    </a>
+  </p>
 </footer>
 
 </body>


### PR DESCRIPTION
## Summary

Moves the Buy Me a Coffee button to the correct location.

### Changes
- **Remove** button from `apps/web/index.html` (Vite SPA entry — wrong location)
- **Add** button to `docs/index.html` footer (GitHub Pages project page — correct location)

Supersedes #37.

### Why
The button belongs on the public-facing GitHub Pages site (`docs/index.html`), not inside the Vite application entry point.