### PR TITLE
fix(docker): run prisma generate before api build

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -9,7 +9,8 @@ COPY packages/finance-engine/package*.json ./packages/finance-engine/
 COPY apps/api/package*.json ./apps/api/
 COPY prisma ./prisma/
 
-RUN npm ci --workspace=packages/shared --workspace=packages/finance-engine --workspace=apps/api
+RUN npm ci --workspace=packages/shared --workspace=packages/finance-engine --workspace=apps/api \
+	&& npx prisma generate
 
 COPY packages/shared ./packages/shared/
 COPY packages/finance-engine ./packages/finance-engine/


### PR DESCRIPTION
## Problem

The Docker API image build is failing with 116 TypeScript errors:

```
src/prisma/prisma.service.ts:2:10 - error TS2305: Module '@prisma/client' has no exported member 'PrismaClient'.
```

All `this.prisma.<model>` calls across every service fail because `@prisma/client` has no generated types.

## Root Cause

`prisma generate` was never called in the Dockerfile build stage. Prisma only provides typed client code after generation — the schema is copied in but the generated client was never produced before `nest build` ran.

## Fix

Add `npx prisma generate` immediately after `npm ci` in the builder stage, chained in the same `RUN` layer.

Fixes the failing `Publish Container Images` workflow.