### PR TITLE
fix(security): resolve moderate Dependabot advisories (yaml #36, ajv #GHSA-2g4f-4pwh-qvx6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7275,15 +7275,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/crc": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,23 +156,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/core/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@angular-devkit/core/node_modules/rxjs": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -3363,23 +3346,6 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@nestjs/schematics/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@nestjs/schematics/node_modules/rxjs": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,10 @@
       "ajv": "^8.18.0"
     },
     "path-to-regexp": "^8.4.0",
-    "picomatch": "^4.0.4"
+    "picomatch": "^4.0.4",
+    "cosmiconfig": {
+      "yaml": "^1.10.3"
+    }
   },
   "devDependencies": {
     "tsx": "^4.21.0"


### PR DESCRIPTION
## Security Fixes

Resolves: https://github.com/JoeRegnier/retiree-plan/security/dependabot/36

### Changes

**1. yaml (Dependabot alert #36 — GHSA-48c2-rrv3-qjmp / CVE-2026-33532)**
- `cosmiconfig@7.1.0` pulls in `yaml ^1.10.0` → was resolving to vulnerable `1.10.2`
- Fix: npm override `cosmiconfig.yaml -> ^1.10.3`

**2. ajv (GHSA-2g4f-4pwh-qvx6)**
- `@angular-devkit/core` and `@nestjs/schematics` had stale lockfile entries at `ajv@8.17.1`
- Existing overrides already targeted `^8.18.0` — cleared stale entries so they take effect
- Now resolves to `ajv@8.18.0`

### Result
- `npm audit`: **0 HIGH, 1 MODERATE** (was 7 before this PR series)
- Remaining 1 moderate: `brace-expansion` in Electron/webpack build tooling — not exploitable, no upstream fix available without breaking changes