### PR TITLE
fix(docker): resolve picomatch MODULE_NOT_FOUND breaking API Docker build

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -49,6 +49,7 @@
     "@types/express": "^5.0.0",
     "@types/multer": "^2.1.0",
     "@types/passport-jwt": "^4.0.0",
+    "picomatch": "^4.0.4",
     "prisma": "^7.6.0",
     "typescript": "^5.8.0",
     "vitest": "^4.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "@types/express": "^5.0.0",
         "@types/multer": "^2.1.0",
         "@types/passport-jwt": "^4.0.0",
+        "picomatch": "^4.0.4",
         "prisma": "^7.6.0",
         "typescript": "^5.8.0",
         "vitest": "^4.1.1"
@@ -138,7 +139,7 @@
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
         "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.2",
+        "picomatch": "4.0.4",
         "rxjs": "7.8.1",
         "source-map": "0.7.4"
       },
@@ -3311,7 +3312,7 @@
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
         "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.2",
+        "picomatch": "4.0.4",
         "rxjs": "7.8.1",
         "source-map": "0.7.4"
       },
@@ -12352,6 +12353,19 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
@@ -14298,19 +14312,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
@@ -14925,19 +14926,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/vitest": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.1.tgz",
@@ -15028,19 +15016,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vitest/node_modules/std-env": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
       "ajv": "^8.18.0"
     },
     "path-to-regexp": "^8.4.0",
-    "picomatch": "^4.0.4",
     "cosmiconfig": {
       "yaml": "^1.10.3"
     }


### PR DESCRIPTION
## Problem

The Docker build for `retiree-plan-api` started failing after PR #53 merged with:

```
Error: Cannot find module 'picomatch'
Require stack:
- /app/node_modules/@angular-devkit/core/src/virtual-fs/host/pattern.js
```

## Root Cause

The security fix in PR #52/53 added a top-level npm override `"picomatch": "^4.0.4"`. However, `@angular-devkit/core@19.2.19` pins picomatch at **exact** version `4.0.2`. When npm encounters an exact-version dependency with a top-level override, it applies the override at resolution time but **does not write an install entry to the lockfile**, resulting in picomatch never being installed anywhere in `node_modules`.

In Docker, `npm ci --workspace=apps/api` (workspace-scoped) strictly follows the lockfile — no lockfile entry means no installation.

## Fix

1. **Remove** the broken top-level `picomatch\1. **Remove** the broken top-level `picomatch\1. **Remove** the broken top-level `picomatch\1. **Remove** the broken top-level `picomatch\1. **Remove** tapp1. **Remove** the broken top-level `picomatch\1. **Remove** the broken top-level kit/core`1. **Remove** the broken top-levelxact-version refs (`4.0.2` → `4.0.4`) for `@angular-devkit/core` entries in `package-lock.1. **Remov Verification

- ✅ `node_modules/picomatch@4.0.4` now at root
- ✅ `require('@angular-devkit/core')` loads successfully  
- ✅ `npm audit`: 0 high, 1 moderate (brace-expansion — unchanged, build tooling only)