### PR TITLE
fix(ci): update rollup→rolldown platform binary workaround for Vite 8

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -62,23 +62,24 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Rollup ships platform-native binaries as optional dependencies. When the
-      # package-lock.json was generated on a different OS (e.g. Linux CI), those
-      # binaries are absent from the lockfile and npm ci skips them, causing
-      # "Cannot find module @rollup/rollup-<platform>" at build time.
+      # Rolldown (Vite 8's Rust-based bundler) ships platform-native binaries as
+      # optional dependencies. When the package-lock.json was generated on a
+      # different OS, those binaries are absent from the lockfile and npm ci
+      # skips them, causing a missing native binding error at build time.
       # This step installs the correct binary for the current runner if missing.
       # See: https://github.com/npm/cli/issues/4828
-      - name: Fix rollup platform binary (npm optional dep workaround)
+      - name: Fix rolldown platform binary (npm optional dep workaround)
         shell: bash
         run: |
-          RVER=$(node -e "process.stdout.write(require('./node_modules/rollup/package.json').version)")
+          RDVER=$(node -e "process.stdout.write(require('./node_modules/rolldown/package.json').version)")
           case "$(node -e 'process.stdout.write(process.platform+"-"+process.arch)')" in
-            darwin-arm64) PKG="@rollup/rollup-darwin-arm64" ;;
-            darwin-x64)   PKG="@rollup/rollup-darwin-x64" ;;
-            win32-x64)    PKG="@rollup/rollup-win32-x64-msvc" ;;
+            darwin-arm64) PKG="@rolldown/binding-darwin-arm64" ;;
+            darwin-x64)   PKG="@rolldown/binding-darwin-x64" ;;
+            win32-x64)    PKG="@rolldown/binding-win32-x64-msvc" ;;
+            linux-x64)    PKG="@rolldown/binding-linux-x64-gnu" ;;
             *)            exit 0 ;;
           esac
-          test -d "node_modules/$PKG" || npm install --no-save --ignore-scripts "$PKG@$RVER"
+          test -d "node_modules/$PKG" || npm install --no-save --ignore-scripts "$PKG@$RDVER"
 
       # Ensure Prisma model types exist before TypeScript builds (notably on Windows)
       - name: Prisma generate (pre-build)


### PR DESCRIPTION
## Problem

The CI workflow's 'Fix rollup platform binary' step was failing on all runners with:
```
Error: Cannot find module './node_modules/rollup/package.json'
```

This caused every Desktop Release CI run to fail on macOS, Windows, and Linux.

## Root Cause

The Vite 8 update (merged via dependabot) replaced `rollup` with `rolldown` (Rust-based bundler). The `rollup` package is no longer installed, so the workaround step that ensures the platform-native binary is available was immediately failing.

## Fix

Updated the step to check for `rolldown`'s platform binary (`@rolldown/binding-*`) instead of `@rollup/rollup-*`. Also added `linux-x64` case coverage for the ubuntu runner.