### PR TITLE
fix(ci): remove --skip-generate from prisma db push (removed in Prisma 7)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -182,8 +182,7 @@ jobs:
           DATABASE_URL="file:$(pwd)/apps/desktop/resources/template.db" \
             npx prisma db push \
               --schema=prisma/schema.prisma \
-              --accept-data-loss \
-              --skip-generate
+              --accept-data-loss
 
       # ── Compile Electron TypeScript ────────────────────────────────────────
       - name: Compile Electron main process


### PR DESCRIPTION
## Problem

The Desktop Release CI was failing on the 'Create template database' step with:
```
! unknown or unexpected option: --skip-generate
```

## Root Cause

The dependabot Prisma update to **Prisma 7.6.0** removed the `--skip-generate` flag from `prisma db push`. This flag was never a standard option in recent Prisma versions, and Prisma 7 fully removed it.

## Fix

Remove `--skip-generate` from the `prisma db push` call in the 'Create template database' step. Verified locally that `prisma db push --schema=prisma/schema.prisma --accept-data-loss` works correctly with Prisma 7.