### PR TITLE
fix(security): pin lodash 4.18.1 as devDep to fix MODULE_NOT_FOUND

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "e2e"
       ],
       "devDependencies": {
+        "lodash": "^4.18.1",
         "tsx": "^4.21.0"
       },
       "engines": {
@@ -11076,6 +11077,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -89,12 +89,12 @@
       "ajv": "^8.18.0"
     },
     "path-to-regexp": "^8.4.0",
-    "lodash": "^4.18.0",
     "cosmiconfig": {
       "yaml": "^1.10.3"
     }
   },
   "devDependencies": {
+    "lodash": "^4.18.1",
     "tsx": "^4.21.0"
   }
 }


### PR DESCRIPTION
## Problem

PR #66 removed `lodash` from the lock file entirely, causing ALL builds to fail:
```
Error: Cannot find module 'lodash/toArray'
  at node_modules/node-emoji/lib/emoji.js
  at @nestjs/cli/lib/ui/emojis.js
```
This broke Desktop Release (all 3 platforms) and Docker container builds.

## Root Cause

The lodash override + Python lock manipulation caused npm to remove lodash from `node_modules` entirely. But `@nestjs/cli` → `node-emoji` still requires `require('lodash/toArray')` at build time.

## Fix

- Remove `"lodash": "^4.18.0"` from `overrides` (npm disallows overrides that conflict with direct deps anyway)
- Add `"lodash": "^4.18.1"` as a `devDependency` — this keeps lodash in node_modules **and** pins it to the safe `4.18.1` which resolves both CVEs

## Verified

- `node -e "require('lodash/toArray')"" → OK
- `nest build` → exit 0
- `npm audit` → **found 0 vulnerabilities**