### PR TITLE
fix(ci): add libsql platform bindings as optionalDeps to fix CI runners

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -42,6 +42,15 @@
     "yahoo-finance2": "^3.14.0",
     "zod": "^4.3.6"
   },
+  "optionalDependencies": {
+    "@libsql/darwin-arm64": "0.5.28",
+    "@libsql/darwin-x64": "0.5.28",
+    "@libsql/linux-x64-gnu": "0.5.28",
+    "@libsql/linux-x64-musl": "0.5.28",
+    "@libsql/linux-arm64-gnu": "0.5.28",
+    "@libsql/linux-arm64-musl": "0.5.28",
+    "@libsql/win32-x64-msvc": "0.5.28"
+  },
   "devDependencies": {
     "@nestjs/cli": "^11.0.0",
     "lodash": "^4.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,15 @@
         "prisma": "^7.6.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.2"
+      },
+      "optionalDependencies": {
+        "@libsql/darwin-arm64": "0.5.28",
+        "@libsql/darwin-x64": "0.5.28",
+        "@libsql/linux-arm64-gnu": "0.5.28",
+        "@libsql/linux-arm64-musl": "0.5.28",
+        "@libsql/linux-x64-gnu": "0.5.28",
+        "@libsql/linux-x64-musl": "0.5.28",
+        "@libsql/win32-x64-msvc": "0.5.28"
       }
     },
     "apps/desktop": {
@@ -2495,6 +2504,19 @@
         "darwin"
       ]
     },
+    "node_modules/@libsql/darwin-x64": {
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.5.28.tgz",
+      "integrity": "sha512-m1hGkQm8A+CjZmR9D5G3zi36na7GXGJomsMbHwOFiCUYPjqRReD5KZ2HZ/qEAV6U/66xPdDDCuqDB8MzNhiwxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
     "node_modules/@libsql/hrana-client": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.9.0.tgz",
@@ -2516,6 +2538,71 @@
         "@types/ws": "^8.5.4",
         "ws": "^8.13.0"
       }
+    },
+    "node_modules/@libsql/linux-arm64-gnu": {
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.5.28.tgz",
+      "integrity": "sha512-gQGJgmUBdk3qm8rDwvFujzTWipLE4ZNP9fgcdVabVBFmD38wLOU5aZ4F3BHrL1ZWdvsrC8mrtnCTKEGuYHDZIw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm64-musl": {
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.5.28.tgz",
+      "integrity": "sha512-zLlgKyG96DKJ4skFtubHbWuWRUW8YpcjHVyKyJJDIp2USPQKLXfB+rT06OSQIS90Bm3dbfU+9rAlNX0ua0cSvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-gnu": {
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.5.28.tgz",
+      "integrity": "sha512-ra+fk6FmTl8ma4opxcTJ8JIt3KrSr+TrFCJtgccfg+7HDdGiE5Ys6jIJMqYuYG61Mv40z3lPZxRivBK5sP9o/w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-musl": {
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.5.28.tgz",
+      "integrity": "sha512-XXl7lHsZEY8szhfMWoe0tFzKXv52nlDt0kckMmtYb97AkKB0bIcxbgx5zTHGyoXLMMhLvEo33OR7NHvjdDyvjw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/win32-x64-msvc": {
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.5.28.tgz",
+      "integrity": "sha512-KLB4TQKkRdki9Ugbz+X986a1F7IaZUZbPuTfPNFi7slTT+biSw0b/LPJ0tCk7EHyo5QmN8tZ1XLZwI7GgUBsfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",


### PR DESCRIPTION
Desktop Release CI fails on ubuntu and windows runners with Cannot find module for libsql platform binaries. npm 11 only adds the current platform binary to package-lock.json. Fix by adding all key platform bindings as optionalDependencies in apps/api/package.json.