### PR TITLE
fix(desktop): normalise Windows DATABASE_URL paths and add API crash log

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -179,7 +179,11 @@ jobs:
         shell: bash
         run: |
           rm -f apps/desktop/resources/template.db
-          DATABASE_URL="file:$(pwd)/apps/desktop/resources/template.db" \
+          # Use Node to resolve an absolute path with forward slashes so that
+          # the file: URI is valid on all platforms (Windows Git Bash emits
+          # POSIX-style paths like /d/a/... which SQLite cannot parse).
+          TEMPLATE_ABS=$(node -e "const p=require('path').resolve('apps/desktop/resources/template.db'); process.stdout.write(p.replace(/\\\\/g,'/'))")
+          DATABASE_URL="file:$TEMPLATE_ABS" \
             npx prisma db push \
               --schema=prisma/schema.prisma \
               --accept-data-loss

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -80,6 +80,15 @@ function ensureDatabase(userDataDir: string): string {
   return dbFile;
 }
 
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+// Prisma/SQLite expect forward-slash paths in the `file:` URI scheme.
+// On Windows, path.join produces backslashes; normalise them here so that
+// DATABASE_URL is always a valid SQLite file URI on every platform.
+function toDbUrl(filePath: string): string {
+  return `file:${filePath.replace(/\\/g, '/')}`;
+}
+
 // ── Wait for API readiness ─────────────────────────────────────────────────────
 
 function waitForApi(url: string, timeoutMs = 30_000): Promise<void> {
@@ -110,12 +119,25 @@ function waitForApi(url: string, timeoutMs = 30_000): Promise<void> {
 //   Node ABI – the build script handles this via @electron/rebuild.
 
 function spawnApi(env: NodeJS.ProcessEnv): void {
+  // In production there is no visible console (especially on Windows), so
+  // redirect the API's stdout/stderr to a log file so users can share it
+  // when diagnosing startup failures.
+  let stdio: 'inherit' | [number, number, number, 'ipc'] = 'inherit';
+  if (!isDev) {
+    try {
+      const logDir = app.getPath('logs');
+      fs.mkdirSync(logDir, { recursive: true });
+      const logFd = fs.openSync(path.join(logDir, 'api.log'), 'w');
+      stdio = [0 as unknown as number, logFd, logFd, 'ipc'];
+    } catch {
+      // If we can't open a log file, fall back to inherit so the app still starts.
+    }
+  }
+
   apiProcess = fork(API_ENTRY, [], {
     execPath: process.execPath,
     env,
-    // Keep stdio in parent process so console.log from nest is visible when
-    // debugging; switch to 'pipe' if you want to suppress API logs.
-    stdio: 'inherit',
+    stdio,
   });
 
   apiProcess.on('exit', (code) =>
@@ -339,7 +361,7 @@ app.whenReady().then(async () => {
         ...process.env,
         NODE_ENV: 'production',
         PORT,
-        DATABASE_URL: `file:${dbPath}`,
+        DATABASE_URL: toDbUrl(dbPath),
         JWT_SECRET: secrets.jwtSecret,
         TOKEN_ENCRYPTION_KEY: secrets.tokenEncryptionKey,
         CORS_ORIGIN: `http://localhost:${PORT}`,
@@ -490,7 +512,7 @@ app.whenReady().then(async () => {
     ...process.env,
     NODE_ENV: 'production',
     PORT,
-    DATABASE_URL: `file:${dbFile}`,
+    DATABASE_URL: toDbUrl(dbFile),
     JWT_SECRET: secrets.jwtSecret,
     TOKEN_ENCRYPTION_KEY: secrets.tokenEncryptionKey,
     // Lock CORS to our own window origin – no wildcard in production.
@@ -505,9 +527,13 @@ app.whenReady().then(async () => {
   try {
     await waitForApi(`http://localhost:${PORT}/api/health`);
   } catch (err) {
+    const logPath = (() => {
+      try { return path.join(app.getPath('logs'), 'api.log'); } catch { return ''; }
+    })();
     dialog.showErrorBox(
       'Startup Error',
-      `Could not start the application server.\n\n${String(err)}`,
+      `Could not start the application server.\n\n${String(err)}` +
+        (logPath ? `\n\nDiagnostic log: ${logPath}` : ''),
     );
     app.quit();
     return;


### PR DESCRIPTION
## Problem
Users on Windows reported that `setup.exe` (v0.27) installs but the app times out on launch.

## Root causes

### 1. Invalid `DATABASE_URL` on Windows
`DATABASE_URL` was built as `file:${dbFile}`. On Windows, `path.join` produces backslashes. SQLite/Prisma require forward slashes in the `file:` URI — the API crashed immediately, `waitForApi` timed out after 30 s, and the app quit.

**Fix**: added `toDbUrl()` helper that normalises backslashes to forward slashes. Both `DATABASE_URL` usages in `main.ts` updated.

### 2. Template database not created correctly on Windows CI
The `Create template database` step used `file:$(pwd)/...`. Git Bash on Windows resolves `$(pwd)` to a POSIX path (`/d/a/...`) that SQLite on Win32 cannot parse. The shipped `template.db` was empty so Prisma crashed on every user's first run.

**Fix**: replaced the Bash `$(pwd)` with `node -e` to resolve and normalise the absolute path on all platforms.

## Additional improvement
Production ElectroProduction ElectroPrviProduction Electr APIProduction ElectroProduction ElectroPrviProduction Electr APIProduction ElectroProductilogs/apProduction Ehe eProduction ElectroProduction Electr Files changed
- `apps/desktop/src/main.ts`
- `.github/workflows/desktop-release.yml`
