### PR TITLE
fix(desktop): stop npm-installing @prisma/client in server bundle on Windows

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -116,24 +116,25 @@ jobs:
             -m
 
       # ── Write server package.json for native deps ─────────────────────────
+      # @prisma/client is intentionally omitted here – it is copied directly
+      # from the root node_modules by the step below so we always embed the
+      # exact version that was used to generate the Prisma client, with all
+      # platform-specific runtime packages already present.  Installing it
+      # fresh via npm on Windows is unreliable (postinstall may fail or produce
+      # a different minor version from the lockfile).
       - name: Write server package.json
         shell: bash
         run: |
           API_BCRYPT_VER=$(node -e "process.stdout.write(require('./apps/api/package.json').dependencies.bcrypt)")
-          PRISMA_VER=$(node -e "process.stdout.write(require('./apps/api/package.json').dependencies['@prisma/client'])")
           COPILOT_VER=$(node -e "process.stdout.write(require('./apps/api/package.json').dependencies['@github/copilot-sdk'] || '')")
-          cat > apps/desktop/resources/server/package.json << EOF
-          {
-            "name": "retiree-plan-server",
-            "version": "$RELEASE_VERSION",
-            "private": true,
-            "dependencies": {
-              "bcrypt": "$API_BCRYPT_VER",
-              "@prisma/client": "$PRISMA_VER"
-              ,"@github/copilot-sdk": "$COPILOT_VER"
-            }
-          }
-          EOF
+          node -e "
+            const fs = require('fs');
+            const deps = { bcrypt: '$API_BCRYPT_VER' };
+            if ('$COPILOT_VER') deps['@github/copilot-sdk'] = '$COPILOT_VER';
+            const pkg = { name: 'retiree-plan-server', version: '$RELEASE_VERSION', private: true, dependencies: deps };
+            fs.writeFileSync('apps/desktop/resources/server/package.json', JSON.stringify(pkg, null, 2));
+            console.log('wrote server package.json', JSON.stringify(pkg.dependencies));
+          "
 
       # ── Install native modules into server bundle ─────────────────────────
       - name: Install server native deps
@@ -146,16 +147,34 @@ jobs:
         env:
           DATABASE_URL: "file:/tmp/dummy-build.db"
 
-      # Copy Prisma artifacts into the server bundle
-      - name: Copy Prisma client into server bundle
+      # Copy Prisma client and all runtime deps into the server bundle.
+      # Uses Node.js fs.cpSync (rmSync first) instead of shell cp -r.
+      # Rationale: `cp -r src dest` when `dest` already exists copies src
+      # INTO dest (GNU cp behaviour), producing wrong nesting.  Node's cpSync
+      # always writes to the exact destination path, regardless of whether it
+      # exists.  The full list covers @prisma/*, .prisma (generated client),
+      # libsql + @libsql/* (SQLite native bindings used by Prisma 7), and the
+      # small utility packages those bindings depend on at runtime.
+      - name: Copy Prisma client and libsql into server bundle
         shell: bash
         run: |
-          if [ -d node_modules/.prisma ]; then
-            cp -r node_modules/.prisma apps/desktop/resources/server/node_modules/.prisma
-          fi
-          if [ -d node_modules/@prisma/client ]; then
-            cp -r node_modules/@prisma/client apps/desktop/resources/server/node_modules/@prisma/client
-          fi
+          node -e "
+            const fs = require('fs'), path = require('path');
+            const root = 'node_modules';
+            const dst  = 'apps/desktop/resources/server/node_modules';
+            const pkgs = [
+              '.prisma', '@prisma', '@libsql', 'libsql',
+              '@neon-rs', 'async-mutex', 'detect-libc', 'js-base64', 'promise-limit'
+            ];
+            for (const p of pkgs) {
+              const s = path.join(root, p);
+              const d = path.join(dst,  p);
+              if (!fs.existsSync(s)) { console.log('skip (not found):', p); continue; }
+              fs.rmSync(d, { recursive: true, force: true });
+              fs.cpSync(s, d, { recursive: true });
+              console.log('copied:', p);
+            }
+          "
 
       # ── Rebuild native modules for Electron's Node ABI ───────────────────
       - name: Rebuild native modules for Electron


### PR DESCRIPTION
## Problem
`Cannot find module '@prisma/client'` crash on Windows — the Electron app exits immediately after install.

## Root cause

Two bugs in the CI "server bundle assembly" pipeline conspired on Windows:

### 1. `npm install @prisma/client` is unreliable on the Windows runner
Installing `@prisma/client` fresh via npm in the server bundle directory triggers Prisma's postinstall script, which can fail silently or produce a different patch version than the lockfile. On failure, the directory may be absent or incomplete.

### 2. `cp -r src dest` when `dest` exists creates wrong nesting (all platforms)
GNU `cp -r A B` where `B` is an existing directory copies `A` **into** `B`, producing `B/basename(A)`. So after npm installs `@prisma/client`, the subsequent `cp -r node_modules/@prisma/client server/node_modules/@prisma/client` creates `server/node_modules/@prisma/client/client/` (wrong path) instead of overwriting the correct location.

The same bug applied to `.prisma`.

## ## ## ## ## ## ## ##ri## ## ## ## ## # the ## ## ## ## ## ## ## ##ri## ## ## ## ## # the ## ## ## ## ## ## ## ##ri## ## ## ## ## # the ## ## ## ## ded by## ## ## ## reb## ## ## ## ## ## ## ##ri## ## ## ## ## # the ## ## ## ## ## ## ## ##ri##*: ## ## ## ## ## ## ## ##ri## ## ## ## ## # the ## ## ## ## ## ## ## ##r T## ## ## ## ## ## ## ##ri## ## ## ## ## # the ## ## ## ## ## ## ## ##ri## ## ## ## ## # the ## ## ## ## ## ## ## ##ri## ## ## ## ## # the ## ## ## ## ded by## ## ## ## reb## ## ## ## ## ## ## ##ri## ## ## ## ## # the ## ## ## ## ## ## ## ##ri##the Prisma 7 SQLite adapter chain (`@libsql/client → libsql → @libsql/<platform>`).
- **Replaced heredoc package.json write with `node -e` + `fs.writeFileSync`**: avoids bash heredoc indentation/quoting quirks on Windows Git Bash.

## Files changed
- `.github/workflows/desktop-release.yml`
