### PR TITLE
fix: afterPack hook to copy server node_modules into packaged app

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -218,13 +218,10 @@ jobs:
             --module-dir resources/server
 
       # ── Remove server package.json before packaging ────────────────────────
-      # electron-builder v26: when a package.json is present in an extraResources
-      # source directory it applies "smart node_modules copy" — only packages in
-      # the declared dep tree are copied.  This excludes .prisma/client/ (the
-      # generated WASM query compiler) because it is not a declared npm dep.
-      # Removing package.json forces electron-builder to do a literal file copy
-      # governed only by the filter patterns, so the full node_modules tree
-      # (including .prisma/) is written into the installer.
+      # Removing package.json + package-lock.json keeps the installer clean.
+      # node_modules is copied into the packaged app by the afterPack hook
+      # (scripts/afterPack.js) because electron-builder's extraResources
+      # hardcodes a filter that skips top-level node_modules directories.
       # NOTE: must come AFTER Rebuild native modules (electron-rebuild needs
       # package.json to locate native modules).
       - name: Remove server package.json before packaging

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -42,7 +42,7 @@ import { ScheduleModule } from '@nestjs/schedule';
           }),
         ]
       : []),
-    ConfigModule.forRoot({ isGlobal: true }),
+    ConfigModule.forRoot({ isGlobal: true, envFilePath: ['.env', '../../.env'] }),
     ScheduleModule.forRoot(),
     PrismaModule,
     DatabaseModule,

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -12,14 +12,15 @@ files:
 asar: true
 
 # ── Resources shipped alongside the asar ──────────────────────────────────────
+# NOTE: electron-builder hardcodes `return false` for any top-level
+# "node_modules" in extraResources. The afterPack hook copies it instead.
+afterPack: scripts/afterPack.js
+
 extraResources:
   - from: resources/server
     to: server
     filter:
       - "**/*"        # all non-hidden files and directories
-      - "**/.*/**"    # files inside hidden directories (e.g. .prisma/client/*)
-      - "!**/node_modules/.bin/**"  # skip .bin symlinks (platform-relative, not needed)
-      - "!**/node_gyp_bins"
   - from: resources/web
     to: web
     filter:

--- a/apps/desktop/scripts/afterPack.js
+++ b/apps/desktop/scripts/afterPack.js
@@ -1,0 +1,39 @@
+// electron-builder afterPack hook
+// -----------------------------------------------------------------
+// electron-builder hard-codes `return false` for any top-level
+// "node_modules" directory inside extraResources (see createFilter
+// in builder-util).  This hook copies the server node_modules that
+// electron-builder refuses to include.
+// -----------------------------------------------------------------
+
+const path = require('path');
+const fs = require('fs');
+
+module.exports = async function afterPack(context) {
+  const serverSrc = path.join(__dirname, '..', 'resources', 'server', 'node_modules');
+  if (!fs.existsSync(serverSrc)) {
+    console.log('[afterPack] No server node_modules to copy – skipping.');
+    return;
+  }
+
+  const resourcesDir = context.packager.getResourcesDir(context.appOutDir);
+
+  const serverDest = path.join(resourcesDir, 'server', 'node_modules');
+
+  console.log(`[afterPack] Copying server node_modules\n  from: ${serverSrc}\n    to: ${serverDest}`);
+
+  fs.cpSync(serverSrc, serverDest, { recursive: true });
+
+  // Remove .bin symlinks and node_gyp_bins — they break macOS code signing
+  // and are not needed at runtime.
+  const binDir = path.join(serverDest, '.bin');
+  if (fs.existsSync(binDir)) {
+    fs.rmSync(binDir, { recursive: true, force: true });
+  }
+  const gypBins = path.join(serverDest, 'bcrypt', 'build', 'node_gyp_bins');
+  if (fs.existsSync(gypBins)) {
+    fs.rmSync(gypBins, { recursive: true, force: true });
+  }
+
+  console.log('[afterPack] Done.');
+};


### PR DESCRIPTION
## Problem

electron-builder hardcodes a filter in `createFilter` (builder-util) that rejects any top-level `node_modules` directory inside `extraResources`. This is why v0.0.29–v0.0.33 all shipped ~103MB installers without `node_modules` despite the directory existing in `resources/server/`.

## Root Cause

In electron-builder's file walker, any path where the relative segment equals `"node_modules"` at the top level returns `false` — unconditionally. No amount of filter pattern tweaking can override this.

## Fix

- **`apps/desktop/scripts/afterPack.js`** — new afterPack hook that copies `resources/server/node_modules` into the packaged app after electron-builder completes its own copy. Also strips `.bin` symlinks and `node_gyp_bins` (break macOS code signing).
- **`apps/desktop/electron-builder.yml`** — adds `afterPack: scripts/afterPack.js`, simplifies extraResources filter (no need for `**/.*/**` now).
- **`.github/workflows/desktop-release.yml`** — updated comment on the pa- **`.github/workflows/desktop-release.yml`** — updated comment on the pa- **`.github/workflows/desktop-release.yml`** — updated comment on the pa- **`.github/workflows/desktop-release.yml`** — updated comment on the pa- **`.github/workflows/desktop-release.yml`** — updated cien- **`.girisma/client` (WASM query compiler)
- `bcrypt` (native)
- `@github/copilot-sdk`