### PR TITLE
ci: remove --verify-tag (no checkout in release job)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -364,7 +364,6 @@ jobs:
           gh release create "$TAG" \
             --title "Retiree Plan ${VERSION}" \
             --generate-notes \
-            --verify-tag \
             $PRERELEASE \
             "${FILES[@]}"
         env:


### PR DESCRIPTION
The Publish GitHub Release job has no checkout step, so `gh release create --verify-tag` fails with 'fatal: not a git repository'. Remove `--verify-tag` — the tag already exists on the remote since the workflow was triggered by a tag push.