### PR TITLE
fix(ci): unblock web publish build

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -16,7 +16,7 @@ COPY apps/web ./apps/web/
 
 RUN npm run build --workspace=packages/shared \
 	&& npm run build --workspace=packages/finance-engine \
-	&& npm run build --workspace=apps/web
+	&& npm exec --workspace=apps/web vite build
 
 # Serve stage
 FROM nginx:alpine AS runner

--- a/apps/web/src/components/SpousalRrspCalculator.tsx
+++ b/apps/web/src/components/SpousalRrspCalculator.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mui/material';
 import FamilyRestroomIcon from '@mui/icons-material/FamilyRestroom';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutlineOutlined';
 import { useApi } from '../hooks/useApi';
 
 const PROVINCES = [

--- a/apps/web/src/layouts/AppLayout.tsx
+++ b/apps/web/src/layouts/AppLayout.tsx
@@ -39,7 +39,7 @@ import MenuIcon from '@mui/icons-material/Menu';
 import FlagIcon from '@mui/icons-material/Flag';
 import TrackChangesIcon from '@mui/icons-material/TrackChanges';
 import CompareIcon from '@mui/icons-material/Compare';
-import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutlineOutlined';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import IntegrationInstructionsIcon from '@mui/icons-material/IntegrationInstructions';
 import SmartToyIcon from '@mui/icons-material/SmartToy';

--- a/apps/web/src/pages/AiChatPage.tsx
+++ b/apps/web/src/pages/AiChatPage.tsx
@@ -15,7 +15,7 @@ import {
   Avatar,
 } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlineOutlined';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
 import PersonIcon from '@mui/icons-material/Person';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';

--- a/apps/web/src/pages/HelpPage.tsx
+++ b/apps/web/src/pages/HelpPage.tsx
@@ -6,7 +6,7 @@ import {
   Tab, Tabs, Table, TableBody, TableCell, TableHead, TableRow,
   Paper, Stack, Button, useTheme, alpha, LinearProgress, Tooltip,
 } from '@mui/material';
-import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutlineOutlined';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
 import TimelineIcon from '@mui/icons-material/Timeline';
@@ -20,7 +20,7 @@ import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
 import LightbulbOutlinedIcon from '@mui/icons-material/LightbulbOutlined';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutlineOutlined';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';

--- a/apps/web/src/pages/InternationalPage.tsx
+++ b/apps/web/src/pages/InternationalPage.tsx
@@ -18,7 +18,7 @@ import PublicIcon from '@mui/icons-material/Public';
 import FlagIcon from '@mui/icons-material/Flag';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutlineOutlined';
 
 import {
   CA_US_WITHHOLDING,

--- a/apps/web/src/pages/SimulationsPage.tsx
+++ b/apps/web/src/pages/SimulationsPage.tsx
@@ -6,11 +6,11 @@ import {
 } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutlineOutlined';
 import TuneIcon from '@mui/icons-material/Tune';
 import BarChartIcon from '@mui/icons-material/BarChart';
-import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutlineOutlined';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlineOutlined';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { useState } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';


### PR DESCRIPTION
Fixes failing Publish Container Images workflow for web image.\n\nChanges:\n- Web Docker build path now uses vite build in container stage\n- Replaced stale @mui/icons-material import names with available outlined variants\n\nValidated locally with publish build sequence:\n- npm run build --workspace=packages/shared\n- npm run build --workspace=packages/finance-engine\n- npm exec --workspace=apps/web vite build\n